### PR TITLE
CreateBookPageでBookCoverClientを使用する

### DIFF
--- a/Experience2Notion_App/CreateBookPageFunction.cs
+++ b/Experience2Notion_App/CreateBookPageFunction.cs
@@ -9,11 +9,11 @@ using System.Text.Json;
 
 namespace Experience2Notion_App;
 
-public class CreateBookPageFunction(ILogger<CreateBookPageFunction> logger, GoogleBookSeacher googleBookSeacher, GoogleEngineSearcher googleEngineSearcher, NotionClient notionClient)
+public class CreateBookPageFunction(ILogger<CreateBookPageFunction> logger, GoogleBookSeacher googleBookSeacher, BookCoverClient bookCoverClient, NotionClient notionClient)
 {
     private readonly ILogger<CreateBookPageFunction> _logger = logger;
     private readonly GoogleBookSeacher _googleBookSeacher = googleBookSeacher;
-    private readonly GoogleEngineSearcher _googleEngineSearcher = googleEngineSearcher;
+    private readonly BookCoverClient _bookCoverClient = bookCoverClient;
     private readonly NotionClient _notionClient = notionClient;
 
     [Function("CreateBookPage")]
@@ -26,13 +26,13 @@ public class CreateBookPageFunction(ILogger<CreateBookPageFunction> logger, Goog
             var data = JsonSerializer.Deserialize<CreateBookRequest>(requestBody);
             if (data is null || string.IsNullOrWhiteSpace(data.Isbn))
             {
-                return new BadRequestObjectResult("ISBNÇ™éwíËÇ≥ÇÍÇƒÇ¢Ç‹ÇπÇÒÅB");
+                return new BadRequestObjectResult("ISBN„ÅåÊåáÂÆö„Åï„Çå„Å¶„ÅÑ„Åæ„Åõ„Çì„ÄÇ");
             }
 
             var book = await _googleBookSeacher.SearchByIsbnAsync(data.Isbn);
-            var (imageData, mime) = await _googleEngineSearcher.DownloadImageAsync($"{book.Title} {string.Join(' ', book.Authors)}");
+            var (imageData, mime) = await _bookCoverClient.DownloadCoverAsync(data.Isbn, book);
             var imageId = await _notionClient.UploadImageAsync($"{book.Title}.jpg", imageData, mime);
-            var result = await _notionClient.CreateBookPageAsync(book.Title, book.Authors, book.CanonicalVolumeLink, book.PublishedDate, imageId);
+            var result = await _notionClient.CreateBookPageAsync(book.Title, book.Authors ?? [], book.CanonicalVolumeLink, book.PublishedDate, imageId);
             return new OkObjectResult(result);
         }
         catch (Experience2NotionException ex)

--- a/Experience2Notion_App/Program.cs
+++ b/Experience2Notion_App/Program.cs
@@ -15,6 +15,7 @@ builder.Services
 builder.Services.AddSingleton<GoogleBookSeacher>();
 builder.Services.AddSingleton<GoogleEngineSearcher>();
 builder.Services.AddSingleton<SpotifyClient>();
+builder.Services.AddSingleton<BookCoverClient>();
 builder.Services.AddSingleton<NotionClient>();
 
 builder.Build().Run();


### PR DESCRIPTION
## 概要

- `CreateBookPage` の書籍表紙取得を `GoogleEngineSearcher` から `BookCoverClient` に差し替え
- `BookCoverClient` を DI に登録
- 書籍ページ作成時に著者が null の場合も空配列として扱う

## 確認

- `dotnet build Experience2Notion/Experience2Notion.csproj`
- `dotnet build Experience2Notion_App/Experience2Notion_App.csproj`

関連 Issue: sasakura870/Experience2Notion#24